### PR TITLE
Cache resolved paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,15 +85,24 @@ const getWebpackResolveRules = function(webpackConfig) {
 
 const resolveRules = getWebpackResolveRules(webpackConfig);
 
+const resolver = ResolverFactory.createResolver(
+  Object.assign(
+    {
+      fileSystem: require("fs"),
+      useSyncFileSystemCalls: true
+    },
+    resolveRules
+  )
+);
+
+const cache = {};
+
 module.exports = function(value, options) {
-  const resolver = ResolverFactory.createResolver(
-    Object.assign(
-      {
-        fileSystem: require("fs"),
-        useSyncFileSystemCalls: true
-      },
-      resolveRules
-    )
-  );
-  return resolver.resolveSync({}, options.basedir, value);
+  const key = options.basedir + value;
+
+  if (!cache[key]) {
+    cache[key] = resolver.resolveSync({}, options.basedir, value);
+  }
+
+  return cache[key];
 };


### PR DESCRIPTION
I noticed that this plugin was slower than I would have expected. The exported function is run with the same inputs over and over, and I believe those can be cached without losing anything.

I'm making an assumption here, that people's webpack configs won't be changing while they're running tests. This seems like a safe assumption but I could be wrong.