### PR TITLE
Fix the possibility of an absolute path.

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ const getJestConfig = function(cliConfigParameter) {
     if (!file || !fs.existsSync(file)) {
       continue;
     }
-    const filePath = path.join(root, file);
+    const filePath = path.isAbsolute(file) ? file : path.join(root, file);
     const configFile = require(filePath);
     if (configFile) {
       return configFile;


### PR DESCRIPTION
PHPStorm has a problem. PHPStorm provides an absolute path to the config file, which is not accepted by your module. Error:

Cannot find module '/Users/.../projects/.../.../Users/.../projects/.../.../jest.config.json'